### PR TITLE
fix Issus #108 and  #36 - fix switching between h264 vs h 265

### DIFF
--- a/slscore/SLSMapData.cpp
+++ b/slscore/SLSMapData.cpp
@@ -87,8 +87,18 @@ int CSLSMapData::remove(char *key)
             delete array_data;
         }
     	m_map_array.erase(item);
-        return SLS_OK;
+        ret = SLS_OK;
     }
+
+    //remove sps and pps
+    std::map<std::string, ts_info *>::iterator item_ti;
+    item_ti = m_map_ts_info.find(strKey);
+    if (item_ti != m_map_ts_info.end()) {
+        sls_log(SLS_LOG_INFO, "[%p]CSLSMapData::remove, key='%s' delete sps and pps",
+                this, key);
+        m_map_ts_info.erase(item_ti);
+    }
+
     return ret;
 }
 


### PR DESCRIPTION
When the srt push stream is disconnected, ts_info should also be cleared. This will not cause the problem that the pps and sps left over when pushing the stream again are still the same as the first time.