### PR TITLE
adding static passphrase

### DIFF
--- a/sls.conf
+++ b/sls.conf
@@ -14,6 +14,8 @@ srt {                #SRT
     server {
         listen 8080; 
         latency 20; #ms
+        #pbkeylen 32; #srt encryption key length: 16/24/32
+        #passphrase someLongSecret123; #length 10-79
 
         domain_player live.sls.com live-1.sls.com;
         domain_publisher uplive.sls.com;

--- a/slscore/SLSListener.cpp
+++ b/slscore/SLSListener.cpp
@@ -284,12 +284,21 @@ int CSLSListener::start()
     if (NULL == m_srt)
         m_srt = new CSLSSrt();
 
-    int latency = ((sls_conf_server_t*)m_conf)->latency;
+    sls_conf_server_t *conf_server = (sls_conf_server_t*)m_conf;
+    int latency = conf_server->latency;
     if (latency > 0) {
         m_srt->libsrt_set_latency(latency);
     }
+    if (strlen(conf_server->passphrase) > 0) {
+        if (conf_server->pbkeylen > 0) {
+            m_srt->libsrt_set_pbkeylen(conf_server->pbkeylen);
+        }
+        m_srt->libsrt_set_passphrase(conf_server->passphrase);
+    } else if (conf_server->pbkeylen > 0) {
+        sls_log(SLS_LOG_WARNING, "[%p]CSLSListener::start, pbkeylen configured without passphrase; ignoring pbkeylen.", this);
+    }
 
-    m_port = ((sls_conf_server_t*)m_conf)->listen;
+    m_port = conf_server->listen;
     ret = m_srt->libsrt_setup(m_port);
     if (SLS_OK != ret) {
         sls_log(SLS_LOG_ERROR, "[%p]CSLSListener::start, libsrt_setup failure.", this);
@@ -573,6 +582,5 @@ std::string   CSLSListener::get_stat_info()
 	}
 	return m_stat_info;
 }
-
 
 

--- a/slscore/SLSListener.hpp
+++ b/slscore/SLSListener.hpp
@@ -46,6 +46,8 @@ char             domain_publisher[URL_MAX_LEN];
 int              listen;
 int              backlog;
 int              latency;
+int              pbkeylen;
+char             passphrase[URL_MAX_LEN];
 int              idle_streams_timeout;//unit s; -1: unlimited
 char             on_event_url[URL_MAX_LEN];
 SLS_CONF_DYNAMIC_DECLARE_END
@@ -59,6 +61,8 @@ SLS_SET_CONF(server, string, domain_publisher,     "", 1,    URL_MAX_LEN-1),
 SLS_SET_CONF(server, int,    listen,               "listen port", 1024, 10000),
 SLS_SET_CONF(server, int,    backlog,              "how many sockets may be allowed to wait until they are accepted", 1,    1024),
 SLS_SET_CONF(server, int,    latency,              "latency.", 1, 300),
+SLS_SET_CONF(server, int,    pbkeylen,             "srt encryption key length (16/24/32)", 0, 32),
+SLS_SET_CONF(server, string, passphrase,           "srt passphrase", 1, URL_MAX_LEN-1),
 SLS_SET_CONF(server, int,    idle_streams_timeout, "players idle timeout when no publisher" , -1, 86400),
 SLS_SET_CONF(server, string, on_event_url,         "on connect/close http url", 1,    URL_MAX_LEN-1),
 SLS_CONF_CMD_DYNAMIC_DECLARE_END

--- a/slscore/SLSSrt.hpp
+++ b/slscore/SLSSrt.hpp
@@ -106,6 +106,8 @@ public :
     int  libsrt_write(const char *buf, int size);
 
     int  libsrt_socket_nonblock(int enable);
+    void libsrt_set_passphrase(const char *passphrase);
+    void libsrt_set_pbkeylen(int pbkeylen);
 
     int  libsrt_getsockopt(SRT_SOCKOPT optname, const char * optnamestr, void * optval, int * optlen);
     int  libsrt_setsockopt(SRT_SOCKOPT optname, const char * optnamestr, const void * optval, int optlen);


### PR DESCRIPTION
To extend Passphrase functionality adding a static Passphrase function from config.

Added because of quick Time-to-Market for product, more specific implementation follows.